### PR TITLE
docs: update doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For notarization, you need the following things:
 1. Xcode 10 or later installed on your Mac.
 2. An [Apple Developer](https://developer.apple.com/) account.
 3. [An app-specific password for your ADC account’s Apple ID](https://support.apple.com/HT204397).
-4. Your app may need to be signed with harded-runtime and the following entitlements:
+4. Your app may need to be signed with hardened-runtime and the following entitlements:
     1. com.apple.security.cs.allow-jit
     1. com.apple.security.cs.allow-unsigned-executable-memory
     1. com.apple.security.cs.allow-dyld-environment-variables

--- a/README.md
+++ b/README.md
@@ -42,10 +42,7 @@ For notarization, you need the following things:
 1. Xcode 10 or later installed on your Mac.
 2. An [Apple Developer](https://developer.apple.com/) account.
 3. [An app-specific password for your ADC account’s Apple ID](https://support.apple.com/HT204397).
-4. Your app may need to be signed with hardened-runtime and the following entitlements:
-    1. com.apple.security.cs.allow-jit
-    1. com.apple.security.cs.allow-unsigned-executable-memory
-    1. com.apple.security.cs.allow-dyld-environment-variables
+4. Your app may need to be signed with hardened-runtime and [list of entitlements](https://developer.apple.com/documentation/bundleresources/entitlements)
 
 #### Safety when using `appleIdPassword`
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ on the train early.
   * `appPath` String - The absolute path to your `.app` file
   * `appleId` String - The username of your apple developer account
   * `appleIdPassword` String - The password for your apple developer account
-  * `ascProvider` String (optional) - Your [Team ID](https://developer.apple.com/account/#/membership) in App Store Connect. This is necessary if you are part of multiple teams
+  * `ascProvider` String (optional) - Your [Team Short Name](https://forums.developer.apple.com/thread/113798). This is necessary if you are part of multiple teams, you can find it out by running `iTMSTransporter -m provider -u APPLE_DEV_ACCOUNT -p APP_PASSWORD`
 
 #### Prerequisites
 
@@ -42,7 +42,10 @@ For notarization, you need the following things:
 1. Xcode 10 or later installed on your Mac.
 2. An [Apple Developer](https://developer.apple.com/) account.
 3. [An app-specific password for your ADC account’s Apple ID](https://support.apple.com/HT204397).
-
+4. Your app may need to be signed with harded-runtime and the following entitlements:
+  * com.apple.security.cs.allow-jit
+  * com.apple.security.cs.allow-unsigned-executable-memory
+  * com.apple.security.cs.allow-dyld-environment-variables
 
 #### Safety when using `appleIdPassword`
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ For notarization, you need the following things:
 1. Xcode 10 or later installed on your Mac.
 2. An [Apple Developer](https://developer.apple.com/) account.
 3. [An app-specific password for your ADC account’s Apple ID](https://support.apple.com/HT204397).
-4. Your app may need to be signed with hardened-runtime and [list of entitlements](https://developer.apple.com/documentation/bundleresources/entitlements)
+4. Your app may need to be signed with hardened-runtime and the following entitlements:
+    1. com.apple.security.cs.allow-jit
+    1. com.apple.security.cs.allow-unsigned-executable-memory
 
 #### Safety when using `appleIdPassword`
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ For notarization, you need the following things:
 2. An [Apple Developer](https://developer.apple.com/) account.
 3. [An app-specific password for your ADC account’s Apple ID](https://support.apple.com/HT204397).
 4. Your app may need to be signed with harded-runtime and the following entitlements:
-  * com.apple.security.cs.allow-jit
-  * com.apple.security.cs.allow-unsigned-executable-memory
-  * com.apple.security.cs.allow-dyld-environment-variables
+    1. com.apple.security.cs.allow-jit
+    1. com.apple.security.cs.allow-unsigned-executable-memory
+    1. com.apple.security.cs.allow-dyld-environment-variables
 
 #### Safety when using `appleIdPassword`
 


### PR DESCRIPTION
1.  correct the ascProvider parameter doc: this is not necessarily the team id, it should be the team short name as stated in the apple developer forum. https://forums.developer.apple.com/thread/113798 and I've tested this and proved that for our app the team id doesn't work because our team short name is different than our team id. 

2. adding some preliminary doc about signing requirement of harden-runtime and the entitlement, looking for suggestions on that part. 