### PR TITLE
feat: make initDelay an option and add retry in waiting Notarization status

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ on the train early.
   * `appleId` String - The username of your apple developer account
   * `appleIdPassword` String - The password for your apple developer account
   * `ascProvider` String (optional) - Your [Team ID](https://developer.apple.com/account/#/membership) in App Store Connect. This is necessary if you are part of multiple teams
+  * `initDelay` Number (optional) - Time (in milliseconds) to wait before query notarization status from apple with UUID. By default
+  it is set to 10 seconds (10000)
 
 #### Prerequisites
 
@@ -80,6 +82,7 @@ async function packageTask () {
     appleId,
     appleIdPassword,
     ascProvider, // This parameter is optional
+    initDelay,   // This parameter is optional
   });
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export async function startNotarize(opts: NotarizeStartOptions): Promise<Notariz
 
 export async function waitForNotarize(opts: NotarizeWaitOptions): Promise<void> {
 
-  var RequestUUID_NOT_FOUND_ERROR_MSG: string = 'Could not find the RequestUUID';
+  const RequestUUID_NOT_FOUND_ERROR_MSG: string = 'Could not find the RequestUUID';
   var retry: number = 0;
 
   d('checking notarization status:', opts.uuid);

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,7 @@ export async function notarize({
    * and this step will fail.  It takes Apple a number of minutes
    * to actually complete the job so an extra delay here is necessary
    */
-  d(`notarization started, waiting for ${initDelay} seconds before pinging Apple for status`);
+  d(`notarization started, waiting for ${initDelay/1000} seconds before pinging Apple for status`);
   await delay(initDelay);
   d('starting to poll for notarization status');
   await waitForNotarize({ uuid, appleId, appleIdPassword, initDelay});

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export async function waitForNotarize(opts: NotarizeWaitOptions): Promise<void> 
   // retry up to 10 times if getting 'Could not find the RequestUUID' error
   // sometimes this is because service delay on apple service
   while ((retry < 10) && (result.output.includes(RequestUUID_NOT_FOUND_ERROR_MSG))) {
-    d(`waiting for ${opts.initDelay} seconds before pinging Apple for status`);
+    d(`waiting for ${opts.initDelay/1000} seconds before pinging Apple for status`);
     await delay(opts.initDelay);
     d(`retry #${retry}: pinging Apple for status with UUID`);
     result = await spawn('xcrun', [


### PR DESCRIPTION
this is an attempt to fix https://github.com/electron/electron-notarize/issues/12
making the hard coded 10 seconds wait an option user can pass in to prolong that 
also build-in retries when getting the `Could not find the RequestUUID` error from apple 