### PR TITLE
feat: support for API Key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ on the train early.
 * `options` Object
   * `appBundleId` String - The app bundle identifier your Electron app is using.  E.g. `com.github.electron`
   * `appPath` String - The absolute path to your `.app` file
-  * `appleId` String - The username of your apple developer account
-  * `appleIdPassword` String - The password for your apple developer account
   * `ascProvider` String (optional) - Your [Team ID](https://developer.apple.com/account/#/membership) in App Store Connect. This is necessary if you are part of multiple teams
+  * There are two methods available: user name with password:
+    * `appleId` String - The username of your apple developer account
+    * `appleIdPassword` String - The password for your apple developer account
+  * ... or apiKey with apiIssuer:
+    * `appleApiKey` String - Required for JWT authentication. See Note on JWT authentication below.
+    * `appleApiIssuer` String - Issuer ID. Required if `appleApiKey` is specified.
 
 #### Prerequisites
 
@@ -66,6 +70,12 @@ where `AC_USERNAME` should be replaced with your Apple ID, and then in your code
 const password = `@keychain:AC_PASSWORD`;
 ```
 
+#### Notes on JWT authentication
+
+You can obtain an API key from [Appstore Connect](https://appstoreconnect.apple.com/access/api). Create a key with _App Manager_ access. Note down the Issuer ID and download the `.p8` file. This file is your Api key and comes with the name of `AuthKey_<api_key>.p8`. This is the string you have to supply when calling `notarize`.
+
+Based on the `ApiKey` `altool` will look in the following places for that file:  
+`./private_keys`, `~/private_keys`, `~/.private_keys` and `~/.appstoreconnect/private_keys`.
 
 #### Example Usage
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,17 @@ import { withTempDir, makeSecret, parseNotarizationInfo } from './helpers';
 
 const d = debug('electron-notarize');
 
-export interface NotarizeCredentials {
+export interface NotarizePasswordCredentials {
   appleId: string;
   appleIdPassword: string;
 }
+
+export interface NotarizeApiKeyCredentials {
+  appleApiKey: string;
+  appleApiIssuer: string;
+}
+
+export type NotarizeCredentials = NotarizePasswordCredentials | NotarizeApiKeyCredentials;
 
 export interface NotarizeAppOptions {
   appPath: string;
@@ -28,6 +35,24 @@ export type NotarizeStartOptions = NotarizeAppOptions & NotarizeCredentials & Tr
 export type NotarizeWaitOptions = NotarizeResult & NotarizeCredentials;
 export type NotarizeStapleOptions = Pick<NotarizeAppOptions, 'appPath'>;
 export type NotarizeOptions = NotarizeStartOptions;
+
+function authorizationArgs(opts: NotarizeCredentials): string[] {
+  if ('appleId' in opts) {
+    return [
+      '-u',
+      makeSecret(opts.appleId),
+      '-p',
+      makeSecret(opts.appleIdPassword),
+    ]
+  } else {
+    return [
+      '--apiKey',
+      makeSecret(opts.appleApiKey),
+      '--apiIssuer',
+      makeSecret(opts.appleApiIssuer),
+    ]
+  }
+}
 
 export async function startNotarize(opts: NotarizeStartOptions): Promise<NotarizeResult> {
   d('starting notarize process for app:', opts.appPath);
@@ -51,10 +76,7 @@ export async function startNotarize(opts: NotarizeStartOptions): Promise<Notariz
       zipPath,
       '--primary-bundle-id',
       opts.appBundleId,
-      '-u',
-      makeSecret(opts.appleId),
-      '-p',
-      makeSecret(opts.appleIdPassword),
+      ...authorizationArgs(opts)
     ];
 
     if (opts.ascProvider) {
@@ -86,10 +108,7 @@ export async function waitForNotarize(opts: NotarizeWaitOptions): Promise<void> 
     'altool',
     '--notarization-info',
     opts.uuid,
-    '-u',
-    makeSecret(opts.appleId),
-    '-p',
-    makeSecret(opts.appleIdPassword),
+    ...authorizationArgs(opts)
   ]);
   if (result.code !== 0) {
     throw new Error(
@@ -142,16 +161,14 @@ export async function stapleApp(opts: NotarizeStapleOptions): Promise<void> {
 export async function notarize({
   appBundleId,
   appPath,
-  appleId,
-  appleIdPassword,
   ascProvider,
+  ...authOptions
 }: NotarizeOptions) {
   const { uuid } = await startNotarize({
     appBundleId,
     appPath,
-    appleId,
-    appleIdPassword,
     ascProvider,
+    ...authOptions
   });
   /**
    * Wait for Apples API to initialize the status UUID
@@ -164,7 +181,7 @@ export async function notarize({
   d('notarization started, waiting for 10 seconds before pinging Apple for status');
   await delay(10000);
   d('starting to poll for notarization status');
-  await waitForNotarize({ uuid, appleId, appleIdPassword });
+  await waitForNotarize({ uuid, ...authOptions });
   await stapleApp({ appPath });
 }
 


### PR DESCRIPTION
In 2018 Apple introduced the Appstore connect API. This provides a way to use JWT tokens to authenticate.

As I noted in #16 current versions of `altool` also support this way of authenticating. This PR adds the necessary options.

I am not sure what to do about `ascProvider` (aka the `-itc_provider` parameter). It is no longer mentioned in `altool`. Shall we remove it as well?

Closes #16