### PR TITLE
Add ability to notarize dmg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,23 +52,30 @@ function authorizationArgs(opts: NotarizeCredentials): string[] {
 export async function startNotarize(opts: NotarizeStartOptions): Promise<NotarizeResult> {
   d('starting notarize process for app:', opts.appPath);
   return await withTempDir<NotarizeResult>(async dir => {
-    const zipPath = path.resolve(dir, `${path.basename(opts.appPath, '.app')}.zip`);
-    d('zipping application to:', zipPath);
-    const zipResult = await spawn('zip', ['-r', '-y', zipPath, path.basename(opts.appPath)], {
-      cwd: path.dirname(opts.appPath),
-    });
-    if (zipResult.code !== 0) {
-      throw new Error(
-        `Failed to zip application, exited with code: ${zipResult.code}\n\n${zipResult.output}`,
-      );
-    }
-    d('zip succeeded, attempting to upload to Apple');
+      let filePath;
+      if (path.extname(opts.appPath) == '.dmg') {
+          filePath = path.resolve(dir, opts.appPath)
+      } else {
+          const zipPath = path.resolve(dir, `${path.basename(opts.appPath, '.app')}.zip`);
+          d('zipping application to:', zipPath);
+          const zipResult = await spawn('zip', ['-r', '-y', zipPath, path.basename(opts.appPath)], {
+              cwd: path.dirname(opts.appPath),
+          });
+          if (zipResult.code !== 0) {
+              throw new Error(
+                  `Failed to zip application, exited with code: ${zipResult.code}\n\n${zipResult.output}`,
+              );
+          }
+          d('zip succeeded, attempting to upload to Apple');
+
+          filePath = zipPath;
+      }
 
     const notarizeArgs = [
       'altool',
       '--notarize-app',
       '-f',
-      zipPath,
+      filePath,
       '--primary-bundle-id',
       opts.appBundleId,
       ...authorizationArgs(opts),


### PR DESCRIPTION
To provide signed and notirized DMG file.

https://stackoverflow.com/questions/58169485/is-a-dmg-required-to-be-notarised-to-pass-gatekeeper-on-catalina


Packed app should be notarised first and after packaging to dmg, we should sign and notarize dmg file