### PR TITLE
feat: add validation function for authorizationArgs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,22 +47,18 @@ function isApiKeyCredentials(opts: NotarizeCredentials): opts is NotarizeApiKeyC
 }
 
 export function validateAuthorizationArgs(opts: NotarizeCredentials): NotarizeCredentials {
-  const passwordCreds = opts as NotarizePasswordCredentials;
-  const apiKeyCreds = opts as NotarizeApiKeyCredentials;
-
   const isPassword = isPasswordCredentials(opts);
   const isApiKey = isApiKeyCredentials(opts);
   if (isPassword && isApiKey) {
-    throw new Error('Mixed authentication properties appleId and appleApiKey');
+    throw new Error('Cannot use both password credentials and API key credentials at once');
   }
   if (isPassword) {
+    const passwordCreds = opts as NotarizePasswordCredentials;
     if (!passwordCreds.appleId) {
       throw new Error(
         'The appleId property is required when using notarization with appleIdPassword',
       );
-    }
-
-    if (!passwordCreds.appleIdPassword) {
+    } else if (!passwordCreds.appleIdPassword) {
       throw new Error(
         'The appleIdPassword property is required when using notarization with appleId',
       );
@@ -70,13 +66,12 @@ export function validateAuthorizationArgs(opts: NotarizeCredentials): NotarizeCr
     return passwordCreds;
   }
   if (isApiKey) {
+    const apiKeyCreds = opts as NotarizeApiKeyCredentials;
     if (!apiKeyCreds.appleApiKey) {
       throw new Error(
         'The appleApiKey property is required when using notarization with appleApiIssuer',
       );
-    }
-
-    if (!apiKeyCreds.appleApiIssuer) {
+    } else if (!apiKeyCreds.appleApiIssuer) {
       throw new Error(
         'The appleApiIssuer property is required when using notarization with appleApiKey',
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,11 @@ import * as path from 'path';
 
 import { spawn } from './spawn';
 import { withTempDir, makeSecret, parseNotarizationInfo } from './helpers';
+import { validateAuthorizationArgs, isPasswordCredentials } from './validate-args';
 
 const d = debug('electron-notarize');
+
+export { validateAuthorizationArgs } from './validate-args';
 
 export interface NotarizePasswordCredentials {
   appleId: string;
@@ -35,51 +38,6 @@ export type NotarizeStartOptions = NotarizeAppOptions & NotarizeCredentials & Tr
 export type NotarizeWaitOptions = NotarizeResult & NotarizeCredentials;
 export type NotarizeStapleOptions = Pick<NotarizeAppOptions, 'appPath'>;
 export type NotarizeOptions = NotarizeStartOptions;
-
-function isPasswordCredentials(opts: NotarizeCredentials): opts is NotarizePasswordCredentials {
-  const creds = opts as NotarizePasswordCredentials;
-  return creds.appleId !== undefined || creds.appleIdPassword !== undefined;
-}
-
-function isApiKeyCredentials(opts: NotarizeCredentials): opts is NotarizeApiKeyCredentials {
-  const creds = opts as NotarizeApiKeyCredentials;
-  return creds.appleApiKey !== undefined || creds.appleApiIssuer !== undefined;
-}
-
-export function validateAuthorizationArgs(opts: NotarizeCredentials): NotarizeCredentials {
-  const isPassword = isPasswordCredentials(opts);
-  const isApiKey = isApiKeyCredentials(opts);
-  if (isPassword && isApiKey) {
-    throw new Error('Cannot use both password credentials and API key credentials at once');
-  }
-  if (isPassword) {
-    const passwordCreds = opts as NotarizePasswordCredentials;
-    if (!passwordCreds.appleId) {
-      throw new Error(
-        'The appleId property is required when using notarization with appleIdPassword',
-      );
-    } else if (!passwordCreds.appleIdPassword) {
-      throw new Error(
-        'The appleIdPassword property is required when using notarization with appleId',
-      );
-    }
-    return passwordCreds;
-  }
-  if (isApiKey) {
-    const apiKeyCreds = opts as NotarizeApiKeyCredentials;
-    if (!apiKeyCreds.appleApiKey) {
-      throw new Error(
-        'The appleApiKey property is required when using notarization with appleApiIssuer',
-      );
-    } else if (!apiKeyCreds.appleApiIssuer) {
-      throw new Error(
-        'The appleApiIssuer property is required when using notarization with appleApiKey',
-      );
-    }
-    return apiKeyCreds;
-  }
-  throw new Error('No authentication properties provided (e.g. appleId, appleApiKey)');
-}
 
 function authorizationArgs(rawOpts: NotarizeCredentials): string[] {
   const opts = validateAuthorizationArgs(rawOpts);

--- a/src/validate-args.ts
+++ b/src/validate-args.ts
@@ -1,0 +1,52 @@
+import {
+  NotarizeApiKeyCredentials,
+  NotarizeCredentials,
+  NotarizePasswordCredentials,
+} from './index';
+
+export function isPasswordCredentials(
+  opts: NotarizeCredentials,
+): opts is NotarizePasswordCredentials {
+  const creds = opts as NotarizePasswordCredentials;
+  return creds.appleId !== undefined || creds.appleIdPassword !== undefined;
+}
+
+export function isApiKeyCredentials(opts: NotarizeCredentials): opts is NotarizeApiKeyCredentials {
+  const creds = opts as NotarizeApiKeyCredentials;
+  return creds.appleApiKey !== undefined || creds.appleApiIssuer !== undefined;
+}
+
+export function validateAuthorizationArgs(opts: NotarizeCredentials): NotarizeCredentials {
+  const isPassword = isPasswordCredentials(opts);
+  const isApiKey = isApiKeyCredentials(opts);
+  if (isPassword && isApiKey) {
+    throw new Error('Cannot use both password credentials and API key credentials at once');
+  }
+  if (isPassword) {
+    const passwordCreds = opts as NotarizePasswordCredentials;
+    if (!passwordCreds.appleId) {
+      throw new Error(
+        'The appleId property is required when using notarization with appleIdPassword',
+      );
+    } else if (!passwordCreds.appleIdPassword) {
+      throw new Error(
+        'The appleIdPassword property is required when using notarization with appleId',
+      );
+    }
+    return passwordCreds;
+  }
+  if (isApiKey) {
+    const apiKeyCreds = opts as NotarizeApiKeyCredentials;
+    if (!apiKeyCreds.appleApiKey) {
+      throw new Error(
+        'The appleApiKey property is required when using notarization with appleApiIssuer',
+      );
+    } else if (!apiKeyCreds.appleApiIssuer) {
+      throw new Error(
+        'The appleApiIssuer property is required when using notarization with appleApiKey',
+      );
+    }
+    return apiKeyCreds;
+  }
+  throw new Error('No authentication properties provided (e.g. appleId, appleApiKey)');
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,73 @@
+import {
+  NotarizeApiKeyCredentials,
+  NotarizeCredentials,
+  NotarizePasswordCredentials,
+  validateAuthorizationArgs,
+} from '../src/index';
+
+describe('index', () => {
+  describe('validateAuthorizationArgs', () => {
+    test('password credentials provided', () => {
+      const opts = {
+        'appleId': 'fakeId',
+        'appleIdPassword': 'fakePassword',
+      } as NotarizePasswordCredentials;
+      expect(validateAuthorizationArgs(opts)).toEqual(opts);
+    });
+
+    test('API key credentials provided', () => {
+      const opts = {
+        'appleApiKey': 'fakeApiKey',
+        'appleApiIssuer': 'fakeApiIssuer',
+      } as NotarizeApiKeyCredentials;
+      expect(validateAuthorizationArgs(opts)).toEqual(opts);
+    });
+
+    test('credentials are required', () => {
+      const opts = {} as NotarizeCredentials;
+      expect(() => validateAuthorizationArgs(opts))
+        .toThrowError(new Error('No authentication properties provided (e.g. appleId, appleApiKey)'));
+    });
+
+    test('only one kind of credentials', () => {
+      const opts = {
+        'appleId': 'fakeId',
+        'appleApiKey': 'fakeApiKey',
+      } as any;
+      expect(() => validateAuthorizationArgs(opts))
+        .toThrowError(new Error('Cannot use both password credentials and API key credentials at once'));
+    });
+
+    test('missing appleId', () => {
+      const opts = {
+        'appleIdPassword': 'fakePassword',
+      } as any;
+      expect(() => validateAuthorizationArgs(opts))
+        .toThrowError(new Error('The appleId property is required when using notarization with appleIdPassword'));
+    });
+
+    test('missing appleIdPassword', () => {
+      const opts = {
+        'appleId': 'fakeId',
+      } as any;
+      expect(() => validateAuthorizationArgs(opts))
+        .toThrowError(new Error('The appleIdPassword property is required when using notarization with appleId'));
+    });
+
+    test('missing appleApiKey', () => {
+      const opts = {
+        'appleApiIssuer': 'fakeApiIssuer',
+      } as any;
+      expect(() => validateAuthorizationArgs(opts))
+        .toThrowError(new Error('The appleApiKey property is required when using notarization with appleApiIssuer'));
+    });
+
+    test('missing appleApiIssuer', () => {
+      const opts = {
+        'appleApiKey': 'fakeApiKey',
+      } as any;
+      expect(() => validateAuthorizationArgs(opts))
+        .toThrowError(new Error('The appleApiIssuer property is required when using notarization with appleApiKey'));
+    });
+  });
+});

--- a/test/validate-args.test.ts
+++ b/test/validate-args.test.ts
@@ -2,8 +2,8 @@ import {
   NotarizeApiKeyCredentials,
   NotarizeCredentials,
   NotarizePasswordCredentials,
-  validateAuthorizationArgs,
 } from '../src/index';
+import { validateAuthorizationArgs } from '../src/validate-args';
 
 describe('index', () => {
   describe('validateAuthorizationArgs', () => {


### PR DESCRIPTION
Adds validation to authorization args. Effectively moves notarize-specific validation out of electron-packager, but enables others to call `validateAuthorizationArgs` in their own package.

This PR is part of enabling API key auth in electron-packager: https://github.com/electron/electron-packager/pull/1127

This is the first time I'm using TypeScript, so if anything looks off, that's probably why! :smile: