### PR TITLE
Support dmg file notarization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,23 +52,30 @@ function authorizationArgs(opts: NotarizeCredentials): string[] {
 export async function startNotarize(opts: NotarizeStartOptions): Promise<NotarizeResult> {
   d('starting notarize process for app:', opts.appPath);
   return await withTempDir<NotarizeResult>(async dir => {
-    const zipPath = path.resolve(dir, `${path.basename(opts.appPath, '.app')}.zip`);
-    d('zipping application to:', zipPath);
-    const zipResult = await spawn('zip', ['-r', '-y', zipPath, path.basename(opts.appPath)], {
-      cwd: path.dirname(opts.appPath),
-    });
-    if (zipResult.code !== 0) {
-      throw new Error(
-        `Failed to zip application, exited with code: ${zipResult.code}\n\n${zipResult.output}`,
-      );
-    }
-    d('zip succeeded, attempting to upload to Apple');
+      let filePath;
+      if (path.extname(opts.appPath) == '.dmg') {
+          filePath = path.resolve(dir, opts.appPath)
+      } else {
+          const zipPath = path.resolve(dir, `${path.basename(opts.appPath, '.app')}.zip`);
+          d('zipping application to:', zipPath);
+          const zipResult = await spawn('zip', ['-r', '-y', zipPath, path.basename(opts.appPath)], {
+              cwd: path.dirname(opts.appPath),
+          });
+          if (zipResult.code !== 0) {
+              throw new Error(
+                  `Failed to zip application, exited with code: ${zipResult.code}\n\n${zipResult.output}`,
+              );
+          }
+          d('zip succeeded, attempting to upload to Apple');
+
+          filePath = zipPath;
+      }
 
     const notarizeArgs = [
       'altool',
       '--notarize-app',
       '-f',
-      zipPath,
+      filePath,
       '--primary-bundle-id',
       opts.appBundleId,
       ...authorizationArgs(opts),

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,24 +52,34 @@ function authorizationArgs(opts: NotarizeCredentials): string[] {
 export async function startNotarize(opts: NotarizeStartOptions): Promise<NotarizeResult> {
   d('starting notarize process for app:', opts.appPath);
   return await withTempDir<NotarizeResult>(async dir => {
-      let filePath;
-      if (path.extname(opts.appPath) == '.dmg') {
-          filePath = path.resolve(dir, opts.appPath)
-      } else {
-          const zipPath = path.resolve(dir, `${path.basename(opts.appPath, '.app')}.zip`);
-          d('zipping application to:', zipPath);
-          const zipResult = await spawn('zip', ['-r', '-y', zipPath, path.basename(opts.appPath)], {
-              cwd: path.dirname(opts.appPath),
-          });
-          if (zipResult.code !== 0) {
-              throw new Error(
-                  `Failed to zip application, exited with code: ${zipResult.code}\n\n${zipResult.output}`,
-              );
-          }
-          d('zip succeeded, attempting to upload to Apple');
-
-          filePath = zipPath;
+    let filePath;
+    if (path.extname(opts.appPath) == '.dmg') {
+      d('copying application to:', filePath);
+      filePath = path.resolve(dir, path.basename(opts.appPath));
+      const cpResult = await spawn('cp', [path.basename(opts.appPath), filePath], {
+        cwd: path.dirname(opts.appPath),
+      });
+      if (cpResult.code !== 0) {
+        throw new Error(
+          `Failed to copy application, exited with code: ${cpResult.code}\n\n${cpResult.output}`,
+        );
       }
+      d('copy succeeded, attempting to upload to Apple');
+    } else if (path.extname(opts.appPath) == '.app') {
+      filePath = path.resolve(dir, `${path.basename(opts.appPath, '.app')}.zip`);
+      d('zipping application to:', filePath);
+      const zipResult = await spawn('zip', ['-r', '-y', filePath, path.basename(opts.appPath)], {
+        cwd: path.dirname(opts.appPath),
+      });
+      if (zipResult.code !== 0) {
+        throw new Error(
+          `Failed to zip application, exited with code: ${zipResult.code}\n\n${zipResult.output}`,
+        );
+      }
+      d('zip succeeded, attempting to upload to Apple');
+    } else {
+      throw new Error(`Unexpected application file type.`);
+    }
 
     const notarizeArgs = [
       'altool',


### PR DESCRIPTION
Support dmg file notarization with modifying @APshenkin 's code to handle dmg file safely, add some debug messages and apply prettier.

Apple seems to support dmg notarization now.
I use this code with electron-builder with calling from `afterAllArtifactBuild ` hooks, then it works well.

![image](https://user-images.githubusercontent.com/955401/78468434-182fd400-7753-11ea-8800-025a11f28b1c.png)

It's in Japanese but it says "Apple checked it. No malicious software detected.".