### PR TITLE
Use ditto instead of zip

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export async function startNotarize(opts: NotarizeStartOptions): Promise<Notariz
   return await withTempDir<NotarizeResult>(async dir => {
     const zipPath = path.resolve(dir, `${path.basename(opts.appPath, '.app')}.zip`);
     d('zipping application to:', zipPath);
-    const zipResult = await spawn('ditto', ['-c', '-k', path.basename(opts.appPath), zipPath], {
+    const zipResult = await spawn('ditto', ['-c', '-k', '--sequesterRsrc', '--keepParent', path.basename(opts.appPath), zipPath], {
       cwd: path.dirname(opts.appPath),
     });
     if (zipResult.code !== 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export async function startNotarize(opts: NotarizeStartOptions): Promise<Notariz
   return await withTempDir<NotarizeResult>(async dir => {
     const zipPath = path.resolve(dir, `${path.basename(opts.appPath, '.app')}.zip`);
     d('zipping application to:', zipPath);
-    const zipResult = await spawn('zip', ['-r', '-y', zipPath, path.basename(opts.appPath)], {
+    const zipResult = await spawn('ditto', ['-c', '-k', path.basename(opts.appPath), zipPath], {
       cwd: path.dirname(opts.appPath),
     });
     if (zipResult.code !== 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,9 +58,13 @@ export async function startNotarize(opts: NotarizeStartOptions): Promise<Notariz
   return await withTempDir<NotarizeResult>(async dir => {
     const zipPath = path.resolve(dir, `${path.basename(opts.appPath, '.app')}.zip`);
     d('zipping application to:', zipPath);
-    const zipResult = await spawn('ditto', ['-c', '-k', '--sequesterRsrc', '--keepParent', path.basename(opts.appPath), zipPath], {
-      cwd: path.dirname(opts.appPath),
-    });
+    const zipResult = await spawn(
+      'ditto',
+      ['-c', '-k', '--sequesterRsrc', '--keepParent', path.basename(opts.appPath), zipPath],
+      {
+        cwd: path.dirname(opts.appPath),
+      },
+    );
     if (zipResult.code !== 0) {
       throw new Error(
         `Failed to zip application, exited with code: ${zipResult.code}\n\n${zipResult.output}`,


### PR DESCRIPTION
Zipped file using "zip" is converting UTF-8 NFD charset to UTF-8 NFC. The new APFS filesystem supports both encodings unlike HFS+ where UTF-8 was always converted to UTF-8 NFD. The notarization process may be failed if we keep using "zip".

For more information: https://blog.frostwire.com/2019/08/27/apple-notarization-the-signature-of-the-binary-is-invalid-one-other-reason-not-explained-in-apple-developer-documentation/