### PR TITLE
feat: Make --keychain option optional

### DIFF
--- a/src/notarytool.ts
+++ b/src/notarytool.ts
@@ -33,7 +33,11 @@ function authorizationArgs(rawOpts: NotaryToolCredentials): string[] {
       makeSecret(opts.appleApiIssuer),
     ];
   } else {
-    return ['--keychain', opts.keychain, '--keychain-profile', opts.keychainProfile];
+    // --keychain is optional -- when not specified, the iCloud keychain is used by notarytool
+    if (opts.keychain) {
+      return ['--keychain', opts.keychain, '--keychain-profile', opts.keychainProfile];
+    }
+    return ['--keychain-profile', opts.keychainProfile];
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export interface NotaryToolApiKeyCredentials {
 
 export interface NotaryToolKeychainCredentials {
   keychainProfile: string;
-  keychain: string;
+  keychain?: string;
 }
 
 export type LegacyNotarizeCredentials =

--- a/src/validate-args.ts
+++ b/src/validate-args.ts
@@ -133,11 +133,7 @@ export function validateNotaryToolAuthorizationArgs(
   }
   if (isKeychain) {
     const keychainCreds = opts as NotaryToolKeychainCredentials;
-    if (!keychainCreds.keychain) {
-      throw new Error(
-        'The keychain property is required when using notarization with keychain credentials',
-      );
-    } else if (!keychainCreds.keychainProfile) {
+    if (!keychainCreds.keychainProfile) {
       throw new Error(
         'The keychainProfile property is required when using notarization with keychain credentials',
       );


### PR DESCRIPTION
When there exists an iCloud keychain, notarytool by default uses that.
The iCloud keychain does not have a local path, and thus cannot be
specified explicitly using --keychain, only implicitly using no
--keychain argument.

Make the opts.keychain argument optional, to allow this (common)
behavior.