### PR TITLE
fix: make notary tool file extension agnostic

### DIFF
--- a/src/notarytool.ts
+++ b/src/notarytool.ts
@@ -45,7 +45,7 @@ export async function isNotaryToolAvailable() {
 export async function notarizeAndWaitForNotaryTool(opts: NotaryToolStartOptions) {
   d('starting notarize process for app:', opts.appPath);
   return await withTempDir(async dir => {
-    const zipPath = path.resolve(dir, `${path.basename(opts.appPath, '.app')}.zip`);
+    const zipPath = path.resolve(dir, `${path.parse(opts.appPath).name}.zip`);
     d('zipping application to:', zipPath);
     const zipResult = await spawn(
       'ditto',


### PR DESCRIPTION
Make Notary Tool file extension agnostic, no need to assume .app extension, for example we may want to notarize .pkg or .dmg